### PR TITLE
Feature/dev 1374 add remove group members

### DIFF
--- a/tests/api/manage/test_usergroup.py
+++ b/tests/api/manage/test_usergroup.py
@@ -16,13 +16,6 @@ def test_create_usergroup_success(mock_xqapi):
     assert result["name"] == "test"
     assert "a@example.com" in result["members"]
 
-
-def test_create_usergroup_error(mock_xqapi):
-    mock_xqapi.api_post = MagicMock(return_value=(500, "mock server error"))
-    with pytest.raises(XQException):
-        create_usergroup(mock_xqapi, name="mockname", members=["mockmember"])
-
-
 def test_create_usergroup_error(mock_xqapi):
     mock_xqapi.api_post = MagicMock(return_value=(500, "error"))
     with pytest.raises(XQException):
@@ -51,19 +44,6 @@ def test_get_usergroup_all(mock_xqapi):
     result = get_usergroup(mock_xqapi)
     assert isinstance(result, dict)
     assert "groups" in result
-
-
-def test_get_usergroup(mock_xqapi):
-    mock_xqapi.api_get = MagicMock(return_value=(500, "mock server error"))
-    with pytest.raises(XQException):
-        get_usergroup(mock_xqapi)
-
-
-def test_get_usergroup(mock_xqapi):
-    mock_xqapi.api_get = MagicMock(return_value=(500, "mock server error"))
-    with pytest.raises(XQException):
-        get_usergroup(mock_xqapi)
-
 
 def test_update_usergroup(mock_xqapi):
     mock_xqapi.api_patch = MagicMock(return_value=(204, "mock server success"))

--- a/tests/api/manage/test_usergroup.py
+++ b/tests/api/manage/test_usergroup.py
@@ -10,15 +10,53 @@ def test_create_usergroup(mock_xqapi):
     assert create_usergroup(mock_xqapi, name="mockname", members=["mockmember"])
 
 
+def test_create_usergroup_success(mock_xqapi):
+    mock_xqapi.api_post = MagicMock(return_value=(200, {"id": 1, "name": "test", "members": ["a@example.com"]}))
+    result = create_usergroup(mock_xqapi, name="test", members=["a@example.com"])
+    assert result["name"] == "test"
+    assert "a@example.com" in result["members"]
+
+
 def test_create_usergroup_error(mock_xqapi):
     mock_xqapi.api_post = MagicMock(return_value=(500, "mock server error"))
     with pytest.raises(XQException):
         create_usergroup(mock_xqapi, name="mockname", members=["mockmember"])
 
 
+def test_create_usergroup_error(mock_xqapi):
+    mock_xqapi.api_post = MagicMock(return_value=(500, "error"))
+    with pytest.raises(XQException):
+        create_usergroup(mock_xqapi, name="fail", members=["fail@example.com"])
+
+
 def test_get_usergroup(mock_xqapi):
     mock_xqapi.api_get = MagicMock(return_value=(200, "mock server success"))
     assert get_usergroup(mock_xqapi)
+
+
+def test_get_usergroup_by_id(mock_xqapi):
+    mock_xqapi.api_get = MagicMock(return_value=(200, {"id": 1, "name": "test"}))
+    result = get_usergroup(mock_xqapi, usergroup_id=1)
+    assert result["id"] == 1
+
+
+def test_get_usergroup_by_name(mock_xqapi):
+    mock_xqapi.api_get = MagicMock(return_value=(200, {"groups": [{"id": 2, "name": "foo"}, {"id": 3, "name": "bar"}]}))
+    result = get_usergroup(mock_xqapi, name="foo")
+    assert result["name"] == "foo"
+
+
+def test_get_usergroup_all(mock_xqapi):
+    mock_xqapi.api_get = MagicMock(return_value=(200, {"groups": [{"id": 1}, {"id": 2}]}))
+    result = get_usergroup(mock_xqapi)
+    assert isinstance(result, dict)
+    assert "groups" in result
+
+
+def test_get_usergroup(mock_xqapi):
+    mock_xqapi.api_get = MagicMock(return_value=(500, "mock server error"))
+    with pytest.raises(XQException):
+        get_usergroup(mock_xqapi)
 
 
 def test_get_usergroup(mock_xqapi):
@@ -32,10 +70,16 @@ def test_update_usergroup(mock_xqapi):
     assert update_usergroup(mock_xqapi, 1, "mockname", "mockmemebers")
 
 
+def test_update_usergroup_success(mock_xqapi):
+    mock_xqapi.api_patch = MagicMock(return_value=(204, {"id": 1, "name": "updated"}))
+    result = update_usergroup(mock_xqapi, 1, "updated", ["a@example.com"])
+    assert result["name"] == "updated"
+
+
 def test_update_usergroup_error(mock_xqapi):
     mock_xqapi.api_patch = MagicMock(return_value=(500, "mock server error"))
     with pytest.raises(XQException):
-        update_usergroup(mock_xqapi, 1, "mockname", "mockmemebers")
+        update_usergroup(mock_xqapi, 1, "fail", ["fail@example.com"])
 
 
 def test_delete_usergroup(mock_xqapi):
@@ -43,7 +87,35 @@ def test_delete_usergroup(mock_xqapi):
     assert delete_usergroup(mock_xqapi, 1)
 
 
+def test_delete_usergroup_success(mock_xqapi):
+    mock_xqapi.api_delete = MagicMock(return_value=(204, "ok"))
+    assert delete_usergroup(mock_xqapi, 1) is True
+
+
 def test_delete_usergroup_error(mock_xqapi):
     mock_xqapi.api_delete = MagicMock(return_value=(500, "mock server error"))
     with pytest.raises(XQException):
         delete_usergroup(mock_xqapi, 1)
+
+
+def test_add_usergroup_members(mock_xqapi):
+    mock_xqapi.api_get = MagicMock(return_value=(200, {"name": "testgroup", "members": [
+        {"kind": "address", "address": "existing@example.com"}
+    ]}))
+    mock_xqapi.api_patch = MagicMock(return_value=(204, {"id": 1, "name": "testgroup"}))
+    result = add_usergroup_members(mock_xqapi, usergroup_id=1, members="new@example.com")
+    call_args = mock_xqapi.api_patch.call_args
+    assert "new@example.com" in call_args[1]["json"]["members"]
+    assert "existing@example.com" in call_args[1]["json"]["members"]
+
+
+def test_remove_usergroup_members(mock_xqapi):
+    mock_xqapi.api_get = MagicMock(return_value=(200, {"name": "testgroup", "members": [
+        {"kind": "address", "address": "keep@example.com"},
+        {"kind": "address", "address": "remove@example.com"}
+    ]}))
+    mock_xqapi.api_patch = MagicMock(return_value=(204, {"id": 1, "name": "testgroup"}))
+    result = remove_usergroup_members(mock_xqapi, usergroup_id=1, members="remove@example.com")
+    call_args = mock_xqapi.api_patch.call_args
+    assert "keep@example.com" in call_args[1]["json"]["members"]
+    assert "remove@example.com" not in call_args[1]["json"]["members"]

--- a/xq/api/__init__.py
+++ b/xq/api/__init__.py
@@ -47,7 +47,9 @@ class XQAPI:
         get_businesses,
         get_business_info,
         switch_business,
-        generate_device_certificate
+        generate_device_certificate,
+        add_usergroup_members,
+        remove_usergroup_members
     )
 
     def __init__(

--- a/xq/api/manage/usergroup.py
+++ b/xq/api/manage/usergroup.py
@@ -89,30 +89,45 @@ def update_usergroup(api, usergroup_id: int, name: str, members: List[str]):
     if status_code == 204:
         return res
     else:
-        raise XQException(message=f"Error updating Dashbaord usergroup: {res}")
+        raise XQException(message=f"Error updating Dashboard usergroup: {res}")
     
 
-def add_usergroup_members(api, usergroup_id: int, members):
+def add_usergroup_members(api, usergroup_id: int = None, name: str = None, members=None):
     """add one or more members to an existing usergroup
 
     Fetches the current group, merges in the new members, and patches the result.
 
     :param api: XQAPI instance
     :type api: XQAPI
-    :param usergroup_id: id of usergroup
-    :type usergroup_id: int
+    :param usergroup_id: id of usergroup, defaults to None
+    :type usergroup_id: int, optional
+    :param name: name of usergroup (alternative to usergroup_id), defaults to None
+    :type name: str, optional
     :param members: member email or list of member emails to add
     :type members: Union[str, List[str]]
     :raises XQException: error adding members to usergroup
     :return: updated usergroup
     :rtype: object
     """
+    if not usergroup_id and not name:
+        raise XQException(message="Either usergroup_id or name must be provided")
+    if not members:
+        raise XQException(message="members must be provided")
     if isinstance(members, str):
         members = [members]
 
     # Fetch existing group to get current members and merge new members avoiding duplicates
-    existing = get_usergroup(api, usergroup_id=usergroup_id)
-    existing_members = [m["address"] for m in existing.get("members", []) if m.get("kind") == "address"]
+    existing = get_usergroup(api, usergroup_id=usergroup_id, name=name)
+    if isinstance(existing, list):
+        raise XQException(message=f"Multiple usergroups found with name: {name}")
+    if usergroup_id is None:
+        usergroup_id = existing["id"]
+    raw_members = existing.get("members", [])
+    existing_members = [
+        m["address"] if isinstance(m, dict) else m
+        for m in raw_members
+        if not isinstance(m, dict) or m.get("kind") == "address"
+    ]
 
     merged = list(set(existing_members + members))
 
@@ -128,27 +143,42 @@ def add_usergroup_members(api, usergroup_id: int, members):
         raise XQException(message=f"Error adding members to Dashboard usergroup: {res}")
 
 
-def remove_usergroup_members(api, usergroup_id: int, members):
+def remove_usergroup_members(api, usergroup_id: int = None, name: str = None, members=None):
     """remove one or more members from an existing usergroup
 
     Fetches the current group, removes the specified members, and patches the result.
 
     :param api: XQAPI instance
     :type api: XQAPI
-    :param usergroup_id: id of usergroup
-    :type usergroup_id: int
+    :param usergroup_id: id of usergroup, defaults to None
+    :type usergroup_id: int, optional
+    :param name: name of usergroup (alternative to usergroup_id), defaults to None
+    :type name: str, optional
     :param members: member email or list of member emails to remove
     :type members: Union[str, List[str]]
     :raises XQException: error removing members from usergroup
     :return: updated usergroup
     :rtype: object
     """
+    if not usergroup_id and not name:
+        raise XQException(message="Either usergroup_id or name must be provided")
+    if not members:
+        raise XQException(message="members must be provided")
     if isinstance(members, str):
         members = [members]
 
     # Fetch existing group to get current members and remove specified members
-    existing = get_usergroup(api, usergroup_id=usergroup_id)
-    existing_members = [m["address"] for m in existing.get("members", []) if m.get("kind") == "address"]
+    existing = get_usergroup(api, usergroup_id=usergroup_id, name=name)
+    if isinstance(existing, list):
+        raise XQException(message=f"Multiple usergroups found with name: {name}")
+    if usergroup_id is None:
+        usergroup_id = existing["id"]
+    raw_members = existing.get("members", [])
+    existing_members = [
+        m["address"] if isinstance(m, dict) else m
+        for m in raw_members
+        if not isinstance(m, dict) or m.get("kind") == "address"
+    ]
 
     updated = [m for m in existing_members if m not in members]
 


### PR DESCRIPTION
- Add_usergroup_members and remove_usergroup_members functions to allow adding/removing of users from groups. 
- Accept name as an alternative to usergroup_id
- Add input validation: require either usergroup_id or name, and require members for add/remove user group members.
- Update docstrings to document new name parameter"